### PR TITLE
🔧 Deploy to leaderboard.mapswipe.org

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,14 @@
 {
   "projects": {
     "default": "msf-mapswipe"
+  },
+  "targets": {
+    "msf-mapswipe": {
+      "hosting": {
+        "leaderboard": [
+          "mapswipe-leaderboard"
+        ]
+      }
+    }
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
-# leaderboard
-A simple leaderboard to allow display and aggregation of user metrics
+# MapSwipe Leaderboard
+
+A simple leaderboard to allow display and aggregation of user metrics for the [MapSwipe](www.mapswipe.org) app.
+
+## Install and build
+
+To get started, simply run
+
+```
+yarn install
+
+yarn build
+```
+
+## Deploy
+
+The app is deployed using Firebase. You can access the live version of the leaderboard at [leaderboard.mapswipe.org](leaderboard.mapswipe.org)
+To deploy a new version, you will need to use the Firebase login and run:
+
+```
+firebase deploy --only hosting:leaderboard
+```

--- a/firebase.json
+++ b/firebase.json
@@ -1,10 +1,7 @@
 {
   "hosting": {
+    "target": "leaderboard",
     "public": "build",
-    "ignore": [
-      "firebase.json",
-      "**/.*",
-      "**/node_modules/**"
-    ]
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
   }
 }


### PR DESCRIPTION
Update target for hosting so that we can deploy to leaderboard.mapswipe.org.